### PR TITLE
added tests for share this button

### DIFF
--- a/cypress/integration/print-share.spec.js
+++ b/cypress/integration/print-share.spec.js
@@ -1,0 +1,49 @@
+const constants = {
+    rootUrl: 'https://www.bcpl.info/blog',
+    selectors: {
+        printButton: 'a.print',
+		shareButton: '.addthis_button_compact',
+		addThisModal: '.at-expanded-menu-mask'
+    }
+};
+
+describe('Print / Share', () => {
+    before(() => {
+        cy.visit(constants.rootUrl);
+    });
+
+    describe('Print Button', () => {
+        beforeEach(() => {
+            cy.get(constants.selectors.printButton).as('printButton');
+        });
+
+        it('should exist', () => {
+            cy.get('@printButton').should('exist');
+        });
+
+        it('should perform a window.print() on click', () => {
+            cy.get('@printButton').then(btn => {
+                const doesCallWindowOnPrint =
+                    btn[0].onclick.toString().indexOf('') > -1;
+                expect(doesCallWindowOnPrint).to.be.equal(true);
+            });
+        });
+    });
+
+    describe('Share', () => {
+        beforeEach(() => {
+            cy.get(constants.selectors.shareButton).as('shareButton');
+        });
+
+        it('should exist', () => {
+            cy.get('@shareButton').should('exist');
+        });
+
+		// TODO: This script takes forver, so we can't really test this functionality
+        // it('should show the add this share model when selected', () => {
+		// 	cy.get('@shareButton').click();
+
+		// 	cy.get(constants.selectors.addThisModal).should('be.visible');
+        // });
+    });
+});


### PR DESCRIPTION
Added tests for https://github.com/baltimorecounty/BCPL-assets/wiki/Breadcrumbs-and-Print-Share-Test-Plan#print-and-share

addresses second part of #440

Note, there is a "TODO" in these changes, the problem is if you load a script external to our domain and you are testing a page in our domain it takes FOREVER. I need to test this outside of the network to see if that is the actual problem.