### PR TITLE
moved namespacer to constants

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,19 +126,26 @@ gulp.task('move-app-directive-templates', () => {
 	});
 });
 
+
 gulp.task('createConstantsTemplate', () => {
-	gulp.src('js/constants.js') 
+	gulp.src([
+		'js/utility/namespacer.js',
+		'js/constants.js'
+	])
+	.pipe(babel({
+		presets: ['es2015']
+	}))
 	.pipe(concat('constants.js'))
 	.pipe(gulp.dest('dist/js'));
 });
-  
+
 gulp.task('process-master-js', () => gulp.src([
-	'js/utility/namespacer.js',
 	'js/utility/*.js',
 	'js/**/*.js',
 	'!js/vendor/**/*.js',
 	'!js/page-specific/**/*.js',
-	'!js/apps/**/*'
+	'!js/apps/**/*',
+	'!js/constants.js'
 ])
 	.pipe(jshint({
 		esversion: 6


### PR DESCRIPTION
In order for us to include the constants in the site like we wan't we needed to move the namespaces script into the constants file.

This allows us to include the constants file before our master js files.

fyi @danfox01