### PR TITLE
Create auto end date

### DIFF
--- a/js/apps/events-page/controllers/eventsPageCtrl.js
+++ b/js/apps/events-page/controllers/eventsPageCtrl.js
@@ -132,12 +132,12 @@
 				startDatePicker &&
                     startDatePicker.setDate($window.moment(eventRequestModel.StartDate).toDate()); // eslint-disable-line no-unused-expressions
 				endDatePicker &&
-                    endDatePicker.setDate($window.moment(eventRequestModel.StartDate).toDate()); // eslint-disable-line no-unused-expressions
+                    endDatePicker.setDate($window.moment(eventRequestModel.EndDate).toDate()); // eslint-disable-line no-unused-expressions
 				vm.userStartDate = $window
 					.moment(eventRequestModel.StartDate)
 					.format('MMMM DD, YYYY');
 				vm.userEndDate = $window
-					.moment(eventRequestModel.EndDate)
+					.moment(eventRequestModel.StartDate)
 					.add(1, 'd')
 					.format('MMMM DD, YYYY');
 			});
@@ -192,6 +192,8 @@
 			});
 		};
 
+	
+
 		vm.filterByDate = () => {
 			vm.areDatesInvalid = !isDateRangeValid(
 				vm.userStartDate,
@@ -212,7 +214,7 @@
 					},
 					{
 						key: 'endDate',
-						val: vm.userEndDate.add(1, 'd')
+						val: vm.userEndDate
 					}
 				]); // This will trigger a location change, therefore getting the new results
 

--- a/js/apps/events-page/controllers/eventsPageCtrl.js
+++ b/js/apps/events-page/controllers/eventsPageCtrl.js
@@ -132,12 +132,13 @@
 				startDatePicker &&
                     startDatePicker.setDate($window.moment(eventRequestModel.StartDate).toDate()); // eslint-disable-line no-unused-expressions
 				endDatePicker &&
-                    endDatePicker.setDate($window.moment(eventRequestModel.EndDate).toDate()); // eslint-disable-line no-unused-expressions
+                    endDatePicker.setDate($window.moment(eventRequestModel.StartDate).toDate()); // eslint-disable-line no-unused-expressions
 				vm.userStartDate = $window
 					.moment(eventRequestModel.StartDate)
 					.format('MMMM DD, YYYY');
 				vm.userEndDate = $window
 					.moment(eventRequestModel.EndDate)
+					.add(1, 'd')
 					.format('MMMM DD, YYYY');
 			});
 
@@ -211,7 +212,7 @@
 					},
 					{
 						key: 'endDate',
-						val: vm.userEndDate
+						val: vm.userEndDate.add(1, 'd')
 					}
 				]); // This will trigger a location change, therefore getting the new results
 

--- a/js/apps/events-page/controllers/eventsPageCtrl.js
+++ b/js/apps/events-page/controllers/eventsPageCtrl.js
@@ -192,15 +192,16 @@
 		};
 
 		vm.filterByDate = () => {
-			vm.areDatesInvalid = !isDateRangeValid(
-				vm.userStartDate,
-				vm.userEndDate
-			);
 			const newRequestModel = Object.assign({}, vm.requestModel);
 
 			newRequestModel.StartDate = vm.userStartDate;
 			newRequestModel.EndDate = vm.userEndDate;
 			newRequestModel.Page = 1;
+
+			vm.areDatesInvalid = !isDateRangeValid(
+				vm.userStartDate,
+				vm.userEndDate
+			);
 
 			if (vm.areDatesInvalid) {
 				vm.userEndDate = $window

--- a/js/apps/events-page/controllers/eventsPageCtrl.js
+++ b/js/apps/events-page/controllers/eventsPageCtrl.js
@@ -203,12 +203,12 @@
 				vm.userEndDate
 			);
 
-			if (vm.areDatesInvalid) {
-				vm.userEndDate = $window
-					.moment(vm.userStartDate)
-					.add(1, 'd')
-					.format('MMMM DD, YYYY');
-			}
+			//if (vm.areDatesInvalid) {
+				//vm.userEndDate = $window
+					//.moment(vm.userStartDate)
+					//.add(1, 'd')
+					//.format('MMMM DD, YYYY');
+			//}
 
 			filterHelperService.setQueryParams([
 				{

--- a/js/apps/events-page/controllers/eventsPageCtrl.js
+++ b/js/apps/events-page/controllers/eventsPageCtrl.js
@@ -191,38 +191,40 @@
 			});
 		};
 
-	
-
 		vm.filterByDate = () => {
 			vm.areDatesInvalid = !isDateRangeValid(
 				vm.userStartDate,
 				vm.userEndDate
 			);
+			const newRequestModel = Object.assign({}, vm.requestModel);
 
-			if (!vm.areDatesInvalid) {
-				const newRequestModel = Object.assign({}, vm.requestModel);
+			newRequestModel.StartDate = vm.userStartDate;
+			newRequestModel.EndDate = vm.userEndDate;
+			newRequestModel.Page = 1;
 
-				newRequestModel.StartDate = vm.userStartDate;
-				newRequestModel.EndDate = vm.userEndDate;
-				newRequestModel.Page = 1;
-
-				filterHelperService.setQueryParams([
-					{
-						key: 'startDate',
-						val: vm.userStartDate
-					},
-					{
-						key: 'endDate',
-						val: vm.userEndDate
-					}
-				]); // This will trigger a location change, therefore getting the new results
-
-				trackEvent({
-					action: 'Date Filter Selection',
-					category: CONSTANTS.analytics.bcplEventsCategory,
-					label: `${vm.userStartDate} - ${vm.userEndDate}`
-				});
+			if (vm.areDatesInvalid) {
+				vm.userEndDate = $window
+					.moment(vm.userStartDate)
+					.add(1, 'd')
+					.format('MMMM DD, YYYY');
 			}
+
+			filterHelperService.setQueryParams([
+				{
+					key: 'startDate',
+					val: vm.userStartDate
+				},
+				{
+					key: 'endDate',
+					val: vm.userEndDate
+				}
+			]); // This will trigger a location change, therefore getting the new results
+
+			trackEvent({
+				action: 'Date Filter Selection',
+				category: CONSTANTS.analytics.bcplEventsCategory,
+				label: `${vm.userStartDate} - ${vm.userEndDate}`
+			});
 		};
 
 		vm.clearFilters = () => {

--- a/js/apps/events-page/controllers/eventsPageCtrl.js
+++ b/js/apps/events-page/controllers/eventsPageCtrl.js
@@ -137,8 +137,7 @@
 					.moment(eventRequestModel.StartDate)
 					.format('MMMM DD, YYYY');
 				vm.userEndDate = $window
-					.moment(eventRequestModel.StartDate)
-					.add(1, 'd')
+					.moment(eventRequestModel.EndDate)
 					.format('MMMM DD, YYYY');
 			});
 

--- a/js/apps/events-page/controllers/eventsPageCtrl.js
+++ b/js/apps/events-page/controllers/eventsPageCtrl.js
@@ -202,14 +202,6 @@
 				vm.userStartDate,
 				vm.userEndDate
 			);
-
-			//if (vm.areDatesInvalid) {
-				//vm.userEndDate = $window
-					//.moment(vm.userStartDate)
-					//.add(1, 'd')
-					//.format('MMMM DD, YYYY');
-			//}
-
 			filterHelperService.setQueryParams([
 				{
 					key: 'startDate',

--- a/js/apps/events-page/directives/datepickers.js
+++ b/js/apps/events-page/directives/datepickers.js
@@ -31,8 +31,7 @@
 			};
 
 			innerScope.updateEndDate = () => {
-				innerScope.areDatesInvalid = isDateRangeInvalid();
-				if (innerScope.areDatesInvalid) {
+				if (isDateRangeInvalid()) {
 					innerScope.userEndDate = $window
 						.moment(innerScope.userStartDate)
 						.add(1, 'd')

--- a/js/apps/events-page/directives/datepickers.js
+++ b/js/apps/events-page/directives/datepickers.js
@@ -20,23 +20,38 @@
 						innerScope.userEndDate = innerScope.userEndDate || getEndDateLocaleString();
 
 						$timeout(() => {
-							if ($window.moment(innerScope.userStartDate).isSameOrBefore(innerScope.userEndDate)) {
-								innerScope.areDatesInvalid = false;
-							} else {
-								innerScope.userEndDate = $window
-									.moment(innerScope.userStartDate)
-									.add(1, 'd')
-									.format('MMMM DD, YYYY');
+							innerScope.areDatesInvalid = isDateRangeInvalid();
+
+							if (!innerScope.areDatesInvalid) {
+								innerScope.filterByDate();
 							}
-							innerScope.filterByDate();
 						});
 					});
 				}
 			};
 
+			innerScope.updateEndDate = () => {
+				innerScope.areDatesInvalid = isDateRangeInvalid();
+
+				if (innerScope.areDatesInvalid) {
+					innerScope.userEndDate = $window
+						.moment(innerScope.userStartDate)
+						.add(1, 'd')
+						.format('MMMM DD, YYYY');
+				}
+				innerScope.filterByDate();
+			};
+
 			innerScope.openFlatpickr = (flatpickrElementId) => {
 				const flatpickr = document.querySelector('#' + flatpickrElementId)._flatpickr; // eslint-disable-line no-underscore-dangle
 				flatpickr.open();
+			};
+
+			const isDateRangeInvalid = () => {
+				if ($window.moment(innerScope.userStartDate).isSameOrBefore(innerScope.userEndDate)) {
+					return false;
+				}
+				return true;
 			};
       
 			angular.element(document).ready(() => {

--- a/js/apps/events-page/directives/datepickers.js
+++ b/js/apps/events-page/directives/datepickers.js
@@ -32,14 +32,16 @@
 
 			innerScope.updateEndDate = () => {
 				innerScope.areDatesInvalid = isDateRangeInvalid();
-
 				if (innerScope.areDatesInvalid) {
 					innerScope.userEndDate = $window
 						.moment(innerScope.userStartDate)
 						.add(1, 'd')
 						.format('MMMM DD, YYYY');
 				}
-				innerScope.filterByDate();
+
+				$timeout(() => {
+					innerScope.filterByDate();
+				});
 			};
 
 			innerScope.openFlatpickr = (flatpickrElementId) => {

--- a/js/apps/events-page/directives/datepickers.js
+++ b/js/apps/events-page/directives/datepickers.js
@@ -22,10 +22,13 @@
 						$timeout(() => {
 							if ($window.moment(innerScope.userStartDate).isSameOrBefore(innerScope.userEndDate)) {
 								innerScope.areDatesInvalid = false;
-								innerScope.filterByDate();
 							} else {
-								innerScope.areDatesInvalid = true;
+								innerScope.userEndDate = $window
+									.moment(innerScope.userStartDate)
+									.add(1, 'd')
+									.format('MMMM DD, YYYY');
 							}
+							innerScope.filterByDate();
 						});
 					});
 				}

--- a/js/apps/events-page/directives/datepickers.js
+++ b/js/apps/events-page/directives/datepickers.js
@@ -54,7 +54,7 @@
 				}
 				return true;
 			};
-      
+
 			angular.element(document).ready(() => {
 				$window.flatpickr('#start-date, #end-date', flatpickrBasicSettings);
 			});

--- a/js/apps/events-page/directives/datepickers.js
+++ b/js/apps/events-page/directives/datepickers.js
@@ -48,12 +48,7 @@
 				flatpickr.open();
 			};
 
-			const isDateRangeInvalid = () => {
-				if ($window.moment(innerScope.userStartDate).isSameOrBefore(innerScope.userEndDate)) {
-					return false;
-				}
-				return true;
-			};
+			const isDateRangeInvalid = () => !$window.moment(innerScope.userStartDate).isSameOrBefore(innerScope.userEndDate);
 
 			angular.element(document).ready(() => {
 				$window.flatpickr('#start-date, #end-date', flatpickrBasicSettings);

--- a/js/apps/events-page/directives/templates/datepickers.html
+++ b/js/apps/events-page/directives/templates/datepickers.html
@@ -1,7 +1,7 @@
 <div class="datepickers">
 	<div class="date-field-wrapper">
 		<label for="start-date" class="sr-only">Start Date</label>
-		<input class="flatpickr flatpickr-input active calendar-datepicker" id="start-date" type="text" placeholder="From..."
+		<input class="flatpickr flatpickr-input active calendar-datepicker" id="start-date" ng-change="updateEndDate()" type="text" placeholder="From..."
 			ng-model="userStartDate">
 		<i class="fa fa-calendar calendar-datepicker-icon" aria-hidden="true" ng-click="openFlatpickr('start-date')"></i>
 	</div>


### PR DESCRIPTION
This adds functionality for the start date to never be greater then the end date only if the start date is selected to be beyond end date. The end date can still be selected to be prior to the start date and will display a red error to the users. This adds ng-change to the start date input field and upon that change validates the dates. If dates are invalid it changes the end date to (start date +1). This removes an annoying error for users while trying to change dates.  